### PR TITLE
fix: duplicate key events in cli mode on windows

### DIFF
--- a/src/ui/cli/main.rs
+++ b/src/ui/cli/main.rs
@@ -211,7 +211,11 @@ fn update_word_count(
 
 fn poll_input() -> Option<u8> {
     if event::poll(std::time::Duration::from_millis(10)).unwrap() {
-        if let Event::Key(KeyEvent { code, modifiers, .. }) = event::read().unwrap() {
+        if let Event::Key(KeyEvent { code, modifiers, kind: _kind, .. }) = event::read().unwrap() {
+            #[cfg(windows)]
+            if _kind != event::KeyEventKind::Press {
+                return None;
+            }
             match (code, modifiers) {
                 (KeyCode::Char('c'), event::KeyModifiers::CONTROL) => Some(0x03), // Ctrl+C
                 (KeyCode::Char('d'), event::KeyModifiers::CONTROL) => Some(0x04), // Ctrl+D


### PR DESCRIPTION
- Closes #6

On Windows, KeyEvents were reported twice for each key press (once on press, once on release). Added a check to prevent duplicate input.

Ref. https://github.com/ratatui/ratatui/issues/347#issuecomment-1651028733