### PR TITLE
fix: resolve dependency errors for no-feature builds

### DIFF
--- a/src/color_scheme.rs
+++ b/src/color_scheme.rs
@@ -1,5 +1,5 @@
-use serde::{Deserialize, Serialize};
 use paste::paste;
+use serde::{Deserialize, Serialize};
 
 use crate::custom_colors::MyColor;
 
@@ -20,9 +20,11 @@ macro_rules! fw_colors {
     ($($name:ident),*) => {
         paste! {
             $(
+                #[cfg(any(feature = "cli", feature = "tui"))]
                 pub fn [<$name _tui>](&self) -> ratatui::style::Color {
                     self.$name().into()
                 }
+                #[cfg(feature = "gui")]
                 pub fn [<$name _mq>](&self) -> macroquad::color::Color {
                     self.$name().into()
                 }
@@ -69,7 +71,18 @@ impl ColorScheme {
         )
     }
 
-    fw_colors!(border_color, ref_color, bg_color, main_color, dimmer_main, text_color, chart_color, correct_color, corrected_color, incorrect_color);
+    fw_colors!(
+        border_color,
+        ref_color,
+        bg_color,
+        main_color,
+        dimmer_main,
+        text_color,
+        chart_color,
+        correct_color,
+        corrected_color,
+        incorrect_color
+    );
 
     pub fn border_color(&self) -> MyColor {
         match self {
@@ -210,7 +223,6 @@ impl ColorScheme {
             ColorScheme::Pink => MyColor::new(255, 30, 30, 255),
         }
     }
-
 }
 
 impl Default for ColorScheme {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,8 +1,8 @@
+use crate::color_scheme::ColorScheme;
+use crate::language::Language;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
-use crate::language::Language;
-use crate::color_scheme::ColorScheme;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct AppConfig {
@@ -42,7 +42,7 @@ impl AppConfig {
         let home = std::env::var("HOME")
             .or_else(|_| std::env::var("USERPROFILE"))
             .map_err(|_| "Unable to find home directory")?;
-        
+
         let config_dir = PathBuf::from(home).join(".config").join("typeman");
         fs::create_dir_all(&config_dir)?;
         Ok(config_dir)
@@ -57,12 +57,10 @@ impl AppConfig {
             Ok(path) => {
                 if path.exists() {
                     match fs::read_to_string(&path) {
-                        Ok(content) => {
-                            match serde_json::from_str::<AppConfig>(&content) {
-                                Ok(config) => config,
-                                Err(_) => Self::default(),
-                            }
-                        }
+                        Ok(content) => match serde_json::from_str::<AppConfig>(&content) {
+                            Ok(config) => config,
+                            Err(_) => Self::default(),
+                        },
                         Err(_) => Self::default(),
                     }
                 } else {

--- a/src/custom_colors.rs
+++ b/src/custom_colors.rs
@@ -11,6 +11,7 @@ impl MyColor {
     }
 }
 
+#[cfg(feature = "gui")]
 impl From<MyColor> for macroquad::color::Color {
     fn from(c: MyColor) -> Self {
         macroquad::color::Color {
@@ -22,6 +23,7 @@ impl From<MyColor> for macroquad::color::Color {
     }
 }
 
+#[cfg(any(feature = "cli", feature = "tui"))]
 impl From<MyColor> for ratatui::style::Color {
     fn from(c: MyColor) -> Self {
         ratatui::style::Color::Rgb(c.r, c.g, c.b)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,9 @@ pub mod ui {
     pub mod gui {
         pub mod config;
         pub mod main;
+        pub mod popup;
         pub mod practice;
         pub mod results;
-        pub mod popup;
     }
 
     #[cfg(feature = "tui")]
@@ -28,23 +28,18 @@ pub mod ui {
     }
 }
 
-#[cfg(feature = "tui")]
+pub mod button_states;
 pub mod color_scheme;
+pub mod config;
+pub mod custom_colors;
 pub mod language;
+pub mod leaderboard;
 pub mod practice;
 pub mod utils;
-pub mod config;
-pub mod leaderboard;
-pub mod button_states;
-pub mod custom_colors;
 
 // Re-export types needed by modules
 #[derive(Parser)]
-#[command(
-    name = "typeman",
-    about = "Welcome to the typeman!",
-    version = "1.0"
-)]
+#[command(name = "typeman", about = "Welcome to the typeman!", version = "1.0")]
 pub struct Cli {
     #[arg(short = 'c', long = "custom", value_name = "FILE", value_hint = ValueHint::FilePath)]
     pub custom_file: Option<PathBuf>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,9 +18,9 @@ pub mod ui {
     pub mod gui {
         pub mod config;
         pub mod main;
+        pub mod popup;
         pub mod practice;
         pub mod results;
-        pub mod popup;
     }
 
     #[cfg(feature = "tui")]
@@ -31,15 +31,14 @@ pub mod ui {
     }
 }
 
-#[cfg(feature = "tui")]
+pub mod button_states;
 pub mod color_scheme;
+pub mod config;
+pub mod custom_colors;
 pub mod language;
+pub mod leaderboard;
 pub mod practice;
 pub mod utils;
-pub mod config;
-pub mod leaderboard;
-pub mod button_states;
-pub mod custom_colors;
 
 #[cfg(feature = "cli")]
 use crate::ui::cli::modes;
@@ -49,7 +48,6 @@ use crate::ui::tui::r#mod as tui_mod;
 
 #[cfg(feature = "gui")]
 use crate::ui::gui::main as gui;
-
 
 #[derive(Parser)]
 #[command(
@@ -144,36 +142,22 @@ pub fn tui_main() {
     }
 }
 
-
 fn main() {
-    #[cfg(any(feature = "cli", feature = "gui"))]
     let args = Cli::parse();
 
-    #[cfg(not(feature = "tui"))]
-    {
-        #[cfg(any(feature = "cli", feature = "gui"))]
-        if args.tui {
-            eprintln!("TUI mode is not available in this build.");
-            std::process::exit(1);
-        }
+    if args.tui && !cfg!(feature = "tui") {
+        eprintln!("TUI mode is not available in this build.");
+        std::process::exit(1);
     }
 
-    #[cfg(not(feature = "gui"))]
-    {
-        #[cfg(any(feature = "cli", feature = "gui"))]
-        if args.gui {
-            eprintln!("GUI mode is not available in this build.");
-            std::process::exit(1);
-        }
+    if args.gui && !cfg!(feature = "gui") {
+        eprintln!("GUI mode is not available in this build.");
+        std::process::exit(1);
     }
 
-    #[cfg(not(feature = "cli"))]
-    {
-        #[cfg(any(feature = "cli", feature = "gui"))]
-        if args.cli {
-            eprintln!("CLI mode is not available in this build.");
-            std::process::exit(1);
-        }
+    if args.cli && !cfg!(feature = "cli") {
+        eprintln!("CLI mode is not available in this build.");
+        std::process::exit(1);
     }
 
     #[cfg(feature = "gui")]
@@ -193,20 +177,7 @@ fn main() {
         ui::tui::r#mod::main().unwrap();
         return;
     }
-
-    #[cfg(all(feature = "gui", not(feature = "tui")))]
-    {
-        gui_main();
-        return;
-    }
-
-    #[cfg(all(feature = "cli", not(any(feature = "tui", feature = "gui"))))]
-    {
-        run_cli(&args);
-        return;
-    }
 }
-
 
 #[cfg(feature = "cli")]
 fn run_cli(args: &Cli) {

--- a/src/practice.rs
+++ b/src/practice.rs
@@ -1,13 +1,11 @@
 use rand::prelude::IndexedRandom;
 
-#[cfg(any(feature = "cli", feature = "gui"))]
 use {
     std::io::Write,
     std::path::Path,
     std::fs,
 };
 
-#[cfg(any(feature = "cli", feature = "gui"))]
 pub const WPM_MIN: f64 = 35.0;
 
 pub const TYPING_LEVELS: [(&str, &[char]); 32] = [
@@ -70,7 +68,6 @@ pub fn create_words(chars: &[char], word_number: usize) -> String {
     reference
 }
 
-#[cfg(any(feature = "cli", feature = "gui"))]
 pub fn save_results(time: f64, accuracy: f64, wpm: f64, level:usize) {
     let results_dir = "practice_results";
     fs::create_dir_all(results_dir).ok();
@@ -91,7 +88,6 @@ pub fn save_results(time: f64, accuracy: f64, wpm: f64, level:usize) {
     file.write_all(stats.as_bytes()).unwrap();
 }
 
-#[cfg(any(feature = "cli", feature = "gui"))]
 pub fn get_prev_best_wpm(level: usize) -> f64 {
     let results_path = format!("practice_results/level_{}.txt", level);
     let contents = match fs::read_to_string(&results_path) {
@@ -130,7 +126,6 @@ pub fn check_if_completed(results_path: &str) -> bool {
     false
 }
 
-#[cfg(any(feature = "tui", feature = "gui"))]
 pub fn get_first_not_done() -> usize {
     for i in 0..TYPING_LEVELS.len() {
         let results_path = format!("practice_results/level_{}.txt", i + 1);


### PR DESCRIPTION
This change allows building the project with individual feature and resolves dependency errors when no features are selected. Previously, attempting to build without any features or with a single feature would fail.

This also contains some code format :). Sorry for the delay.